### PR TITLE
[Feat] 회원가입/로그인/마이페이지 구현

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,82 +1,97 @@
 "use client";
 
-import { useState } from "react";
-import { apiFetch } from "@/lib/backend/client";
-import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import AuthCard from "@/components/auth/AuthCard";
+import InlineBanner from "@/components/ui/InlineBanner";
+import { login } from "@/lib/backend/authApi";
+import { pickMsg } from "@/lib/backend/types";
 
 export default function LoginPage() {
-  const [username, setUsername] = useState(""); // UI상 아이디 입력란
-  const [password, setPassword] = useState("");
   const router = useRouter();
+  const searchParams = useSearchParams();
 
-  const handleLogin = async (e: React.FormEvent) => {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const [pending, setPending] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+
+  // ✅ 회원가입 등에서 넘어온 success 표시
+  // - success 값이 뭐든 "회원가입이 완료되었습니다. 로그인해주세요." 로 고정
+  // - 한번 표시 후 쿼리 제거 (새로고침/뒤로가기 반복 방지)
+  useEffect(() => {
+    const s = searchParams.get("success");
+    if (!s) return;
+
+    setSuccessMsg("회원가입이 완료되었습니다. 로그인해주세요.");
+    router.replace("/auth/login");
+  }, [searchParams, router]);
+
+  const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setErrorMsg(null);
+    setSuccessMsg(null);
 
+    if (!email.trim() || !password.trim()) {
+      setErrorMsg("이메일과 비밀번호를 입력해주세요.");
+      return;
+    }
+
+    setPending(true);
     try {
-      // ✅ 백엔드 컨트롤러의 @RequestMapping("/api/v1/auth") 및 @PostMapping("/login") 확인
-      const res = await apiFetch("/api/v1/auth/login", {
-        method: "POST",
-        // ✅ AuthLoginRequest 레코드의 @NotBlank String email 필드명에 맞춤
-        body: JSON.stringify({
-          email: username,
-          password: password,
-        }),
-      });
-
-      if (res.resultCode && res.resultCode.startsWith("200")) {
-        // ✅ AuthLoginResponse의 nickname 필드 활용
-        alert(`${res.data.nickname}님 환영합니다!`);
-        router.push("/");
-      } else {
-        alert(res.msg || "로그인 실패");
-      }
-    } catch (error) {
-      console.error("로그인 중 오류 발생:", error);
-      alert("이메일 또는 비밀번호를 확인해주세요.");
+      await login(email.trim(), password);
+      router.push("/me");
+      router.refresh();
+    } catch (err: any) {
+      setErrorMsg(pickMsg(err, "로그인에 실패했습니다."));
+    } finally {
+      setPending(false);
     }
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100 text-black">
-      <form
-        onSubmit={handleLogin}
-        className="bg-white p-8 rounded-lg shadow-md w-96"
-      >
-        <h1 className="text-2xl font-bold mb-6 text-center">로그인</h1>
+    <AuthCard title="로그인" sub="이메일과 비밀번호로 로그인합니다.">
+      <form onSubmit={onSubmit} className="space-y-4">
+        {errorMsg && <InlineBanner kind="error" message={errorMsg} />}
+        {successMsg && <InlineBanner kind="success" message={successMsg} />}
 
-        <div className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium mb-1">이메일</label>
-            <input
-              type="email"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              className="w-full p-2 border rounded outline-none focus:ring-1 focus:ring-black"
-              placeholder="example@email.com"
-              required
-            />
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium mb-1">비밀번호</label>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className="w-full p-2 border rounded outline-none focus:ring-1 focus:ring-black"
-              placeholder="********"
-              required
-            />
-          </div>
-
-          <button
-            type="submit"
-            className="w-full bg-black text-white py-2 rounded font-bold hover:bg-gray-800 transition"
-          >
-            로그인하기
-          </button>
+        <div>
+          <div className="mb-1 text-sm text-text-2">이메일</div>
+          <input
+            className="input"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="user1@test.com"
+            autoComplete="email"
+          />
         </div>
+
+        <div>
+          <div className="mb-1 text-sm text-text-2">비밀번호</div>
+          <input
+            className="input"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="••••"
+            autoComplete="current-password"
+          />
+        </div>
+
+        <button className="btn btn-primary w-full" disabled={pending}>
+          {pending ? "로그인 중..." : "로그인"}
+        </button>
+
+        <button
+          type="button"
+          className="btn btn-secondary w-full"
+          onClick={() => router.push("/auth/signup")}
+        >
+          회원가입으로
+        </button>
       </form>
-    </div>
+    </AuthCard>
   );
 }

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import AuthCard from "@/components/auth/AuthCard";
+import InlineBanner from "@/components/ui/InlineBanner";
+import { signup, checkEmailAvailable, checkNicknameAvailable } from "@/lib/backend/authApi";
+import { pickMsg } from "@/lib/backend/types";
+
+type CheckState = "idle" | "invalid" | "checking" | "ok" | "dup" | "error";
+
+function isValidEmail(v: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);
+}
+
+export default function SignupPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [nickname, setNickname] = useState("");
+  const [password, setPassword] = useState("");
+
+  const [pending, setPending] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+
+  const [emailState, setEmailState] = useState<CheckState>("idle");
+  const [nickState, setNickState] = useState<CheckState>("idle");
+
+  // 레이스 방지: 최신 요청만 반영
+  const emailReqId = useRef(0);
+  const nickReqId = useRef(0);
+
+  // ✅ 이메일 자동 체크
+  useEffect(() => {
+    const v = email.trim();
+    if (!v) return setEmailState("idle");
+    if (!isValidEmail(v)) return setEmailState("invalid");
+
+    setEmailState("checking");
+    const myId = ++emailReqId.current;
+
+    const t = setTimeout(async () => {
+      try {
+        const ok = await checkEmailAvailable(v);
+        if (emailReqId.current !== myId) return;
+        setEmailState(ok ? "ok" : "dup");
+      } catch {
+        if (emailReqId.current !== myId) return;
+        setEmailState("error");
+      }
+    }, 400);
+
+    return () => clearTimeout(t);
+  }, [email]);
+
+  // ✅ 닉네임 자동 체크
+  useEffect(() => {
+    const v = nickname.trim();
+    if (!v) return setNickState("idle");
+    if (v.length < 2 || v.length > 30) return setNickState("invalid");
+
+    setNickState("checking");
+    const myId = ++nickReqId.current;
+
+    const t = setTimeout(async () => {
+      try {
+        const ok = await checkNicknameAvailable(v);
+        if (nickReqId.current !== myId) return;
+        setNickState(ok ? "ok" : "dup");
+      } catch {
+        if (nickReqId.current !== myId) return;
+        setNickState("error");
+      }
+    }, 400);
+
+    return () => clearTimeout(t);
+  }, [nickname]);
+
+  const canSubmit = useMemo(() => {
+    const filled = email.trim() && nickname.trim() && password.trim();
+    const checksOk = emailState === "ok" && nickState === "ok";
+    const notChecking = emailState !== "checking" && nickState !== "checking";
+    return Boolean(filled && checksOk && notChecking && !pending);
+  }, [email, nickname, password, emailState, nickState, pending]);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErrorMsg(null);
+    setSuccessMsg(null);
+
+    if (!email.trim() || !nickname.trim() || !password.trim()) {
+      setErrorMsg("이메일/닉네임/비밀번호를 모두 입력해주세요.");
+      return;
+    }
+    if (emailState !== "ok") {
+      setErrorMsg("이메일 중복 확인을 완료해주세요.");
+      return;
+    }
+    if (nickState !== "ok") {
+      setErrorMsg("닉네임 중복 확인을 완료해주세요.");
+      return;
+    }
+
+    setPending(true);
+    try {
+      const rs = await signup(email.trim(), password, nickname.trim());
+      setSuccessMsg(rs.msg || "회원가입이 완료되었습니다.");
+      router.push("/auth/login");
+    } catch (err: any) {
+      setErrorMsg(pickMsg(err, "회원가입에 실패했습니다."));
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const EmailHint = () => {
+    if (emailState === "idle") return null;
+    if (emailState === "invalid") return <div className="mt-1 text-xs text-red-300">이메일 형식이 올바르지 않습니다.</div>;
+    if (emailState === "checking") return <div className="mt-1 text-xs text-text-3">이메일 중복 확인 중...</div>;
+    if (emailState === "dup") return <div className="mt-1 text-xs text-red-300">이미 사용 중인 이메일입니다.</div>;
+    if (emailState === "ok") return <div className="mt-1 text-xs text-emerald-300">사용 가능한 이메일입니다.</div>;
+    return <div className="mt-1 text-xs text-red-300">이메일 확인 중 오류가 발생했습니다.</div>;
+  };
+
+  const NickHint = () => {
+    if (nickState === "idle") return null;
+    if (nickState === "invalid") return <div className="mt-1 text-xs text-red-300">닉네임은 2~30자여야 합니다.</div>;
+    if (nickState === "checking") return <div className="mt-1 text-xs text-text-3">닉네임 중복 확인 중...</div>;
+    if (nickState === "dup") return <div className="mt-1 text-xs text-red-300">이미 사용 중인 닉네임입니다.</div>;
+    if (nickState === "ok") return <div className="mt-1 text-xs text-emerald-300">사용 가능한 닉네임입니다.</div>;
+    return <div className="mt-1 text-xs text-red-300">닉네임 확인 중 오류가 발생했습니다.</div>;
+  };
+
+  return (
+    <AuthCard title="회원가입" sub="이메일/닉네임/비밀번호로 가입합니다.">
+      <form onSubmit={onSubmit} className="space-y-4">
+        {errorMsg && <InlineBanner kind="error" message={errorMsg} />}
+        {successMsg && <InlineBanner kind="success" message={successMsg} />}
+
+        <div>
+          <div className="mb-1 text-sm text-text-2">이메일</div>
+          <input className="input" value={email} onChange={(e) => setEmail(e.target.value)} />
+          <EmailHint />
+        </div>
+
+        <div>
+          <div className="mb-1 text-sm text-text-2">닉네임</div>
+          <input className="input" value={nickname} onChange={(e) => setNickname(e.target.value)} />
+          <NickHint />
+        </div>
+
+        <div>
+          <div className="mb-1 text-sm text-text-2">비밀번호</div>
+          <input className="input" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+        </div>
+
+        <button className="btn btn-primary w-full" disabled={!canSubmit}>
+          {pending ? "가입 중..." : "회원가입"}
+        </button>
+
+        <button type="button" className="btn btn-ghost w-full" onClick={() => router.push("/auth/login")}>
+          로그인으로 돌아가기
+        </button>
+      </form>
+    </AuthCard>
+  );
+}

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -10,158 +10,162 @@ import { pickMsg } from "@/lib/backend/types";
 type CheckState = "idle" | "invalid" | "checking" | "ok" | "dup" | "error";
 
 function isValidEmail(v: string) {
-  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);
 }
 
 export default function SignupPage() {
-  const router = useRouter();
-  const [email, setEmail] = useState("");
-  const [nickname, setNickname] = useState("");
-  const [password, setPassword] = useState("");
+    const router = useRouter();
+    const [email, setEmail] = useState("");
+    const [nickname, setNickname] = useState("");
+    const [password, setPassword] = useState("");
 
-  const [pending, setPending] = useState(false);
-  const [errorMsg, setErrorMsg] = useState<string | null>(null);
-  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+    const [pending, setPending] = useState(false);
+    const [errorMsg, setErrorMsg] = useState<string | null>(null);
+    const [successMsg, setSuccessMsg] = useState<string | null>(null);
 
-  const [emailState, setEmailState] = useState<CheckState>("idle");
-  const [nickState, setNickState] = useState<CheckState>("idle");
+    const [emailState, setEmailState] = useState<CheckState>("idle");
+    const [nickState, setNickState] = useState<CheckState>("idle");
 
-  // 레이스 방지: 최신 요청만 반영
-  const emailReqId = useRef(0);
-  const nickReqId = useRef(0);
+    // 레이스 방지: 최신 요청만 반영
+    const emailReqId = useRef(0);
+    const nickReqId = useRef(0);
 
-  // ✅ 이메일 자동 체크
-  useEffect(() => {
-    const v = email.trim();
-    if (!v) return setEmailState("idle");
-    if (!isValidEmail(v)) return setEmailState("invalid");
+    // ✅ 이메일 자동 체크
+    useEffect(() => {
+        const v = email.trim();
+        if (!v) return setEmailState("idle");
+        if (!isValidEmail(v)) return setEmailState("invalid");
 
-    setEmailState("checking");
-    const myId = ++emailReqId.current;
+        setEmailState("checking");
+        const myId = ++emailReqId.current;
 
-    const t = setTimeout(async () => {
-      try {
-        const ok = await checkEmailAvailable(v);
-        if (emailReqId.current !== myId) return;
-        setEmailState(ok ? "ok" : "dup");
-      } catch {
-        if (emailReqId.current !== myId) return;
-        setEmailState("error");
-      }
-    }, 400);
+        const t = setTimeout(async () => {
+            try {
+                const ok = await checkEmailAvailable(v);
+                if (emailReqId.current !== myId) return;
+                setEmailState(ok ? "ok" : "dup");
+            } catch {
+                if (emailReqId.current !== myId) return;
+                setEmailState("error");
+            }
+        }, 400);
 
-    return () => clearTimeout(t);
-  }, [email]);
+        return () => clearTimeout(t);
+    }, [email]);
 
-  // ✅ 닉네임 자동 체크
-  useEffect(() => {
-    const v = nickname.trim();
-    if (!v) return setNickState("idle");
-    if (v.length < 2 || v.length > 30) return setNickState("invalid");
+    // ✅ 닉네임 자동 체크
+    useEffect(() => {
+        const v = nickname.trim();
+        if (!v) return setNickState("idle");
+        if (v.length < 2 || v.length > 30) return setNickState("invalid");
 
-    setNickState("checking");
-    const myId = ++nickReqId.current;
+        setNickState("checking");
+        const myId = ++nickReqId.current;
 
-    const t = setTimeout(async () => {
-      try {
-        const ok = await checkNicknameAvailable(v);
-        if (nickReqId.current !== myId) return;
-        setNickState(ok ? "ok" : "dup");
-      } catch {
-        if (nickReqId.current !== myId) return;
-        setNickState("error");
-      }
-    }, 400);
+        const t = setTimeout(async () => {
+            try {
+                const ok = await checkNicknameAvailable(v);
+                if (nickReqId.current !== myId) return;
+                setNickState(ok ? "ok" : "dup");
+            } catch {
+                if (nickReqId.current !== myId) return;
+                setNickState("error");
+            }
+        }, 400);
 
-    return () => clearTimeout(t);
-  }, [nickname]);
+        return () => clearTimeout(t);
+    }, [nickname]);
 
-  const canSubmit = useMemo(() => {
-    const filled = email.trim() && nickname.trim() && password.trim();
-    const checksOk = emailState === "ok" && nickState === "ok";
-    const notChecking = emailState !== "checking" && nickState !== "checking";
-    return Boolean(filled && checksOk && notChecking && !pending);
-  }, [email, nickname, password, emailState, nickState, pending]);
+    const canSubmit = useMemo(() => {
+        const filled = email.trim() && nickname.trim() && password.trim();
+        const checksOk = emailState === "ok" && nickState === "ok";
+        const notChecking = emailState !== "checking" && nickState !== "checking";
+        return Boolean(filled && checksOk && notChecking && !pending);
+    }, [email, nickname, password, emailState, nickState, pending]);
 
-  const onSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setErrorMsg(null);
-    setSuccessMsg(null);
+    const onSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setErrorMsg(null);
+        setSuccessMsg(null);
 
-    if (!email.trim() || !nickname.trim() || !password.trim()) {
-      setErrorMsg("이메일/닉네임/비밀번호를 모두 입력해주세요.");
-      return;
-    }
-    if (emailState !== "ok") {
-      setErrorMsg("이메일 중복 확인을 완료해주세요.");
-      return;
-    }
-    if (nickState !== "ok") {
-      setErrorMsg("닉네임 중복 확인을 완료해주세요.");
-      return;
-    }
+        if (!email.trim() || !nickname.trim() || !password.trim()) {
+            setErrorMsg("이메일/닉네임/비밀번호를 모두 입력해주세요.");
+            return;
+        }
+        if (emailState !== "ok") {
+            setErrorMsg("이메일 중복 확인을 완료해주세요.");
+            return;
+        }
+        if (nickState !== "ok") {
+            setErrorMsg("닉네임 중복 확인을 완료해주세요.");
+            return;
+        }
 
-    setPending(true);
-    try {
-      const rs = await signup(email.trim(), password, nickname.trim());
-      setSuccessMsg(rs.msg || "회원가입이 완료되었습니다.");
-      router.push("/auth/login");
-    } catch (err: any) {
-      setErrorMsg(pickMsg(err, "회원가입에 실패했습니다."));
-    } finally {
-      setPending(false);
-    }
-  };
+        setPending(true);
+        try {
+            const rs = await signup(email.trim(), password, nickname.trim());
+            const msg = encodeURIComponent(rs.msg || "회원가입이 완료되었습니다.");
+            router.push(`/auth/login?success=${msg}`);
+        } catch (err: any) {
+            setErrorMsg(pickMsg(err, "회원가입에 실패했습니다."));
+        } finally {
+            setPending(false);
+        }
+    };
 
-  const EmailHint = () => {
-    if (emailState === "idle") return null;
-    if (emailState === "invalid") return <div className="mt-1 text-xs text-red-300">이메일 형식이 올바르지 않습니다.</div>;
-    if (emailState === "checking") return <div className="mt-1 text-xs text-text-3">이메일 중복 확인 중...</div>;
-    if (emailState === "dup") return <div className="mt-1 text-xs text-red-300">이미 사용 중인 이메일입니다.</div>;
-    if (emailState === "ok") return <div className="mt-1 text-xs text-emerald-300">사용 가능한 이메일입니다.</div>;
-    return <div className="mt-1 text-xs text-red-300">이메일 확인 중 오류가 발생했습니다.</div>;
-  };
+    const EmailHint = () => {
+        if (emailState === "idle") return null;
+        if (emailState === "invalid") return <div className="mt-1 text-xs text-red-300">이메일 형식이 올바르지 않습니다.</div>;
+        if (emailState === "checking") return <div className="mt-1 text-xs text-text-3">이메일 중복 확인 중...</div>;
+        if (emailState === "dup") return <div className="mt-1 text-xs text-red-300">이미 사용 중인 이메일입니다.</div>;
+        if (emailState === "ok") return <div className="mt-1 text-xs text-emerald-300">사용 가능한 이메일입니다.</div>;
+        return <div className="mt-1 text-xs text-red-300">이메일 확인 중 오류가 발생했습니다.</div>;
+    };
 
-  const NickHint = () => {
-    if (nickState === "idle") return null;
-    if (nickState === "invalid") return <div className="mt-1 text-xs text-red-300">닉네임은 2~30자여야 합니다.</div>;
-    if (nickState === "checking") return <div className="mt-1 text-xs text-text-3">닉네임 중복 확인 중...</div>;
-    if (nickState === "dup") return <div className="mt-1 text-xs text-red-300">이미 사용 중인 닉네임입니다.</div>;
-    if (nickState === "ok") return <div className="mt-1 text-xs text-emerald-300">사용 가능한 닉네임입니다.</div>;
-    return <div className="mt-1 text-xs text-red-300">닉네임 확인 중 오류가 발생했습니다.</div>;
-  };
+    const NickHint = () => {
+        if (nickState === "idle") return null;
+        if (nickState === "invalid") return <div className="mt-1 text-xs text-red-300">닉네임은 2~30자여야 합니다.</div>;
+        if (nickState === "checking") return <div className="mt-1 text-xs text-text-3">닉네임 중복 확인 중...</div>;
+        if (nickState === "dup") return <div className="mt-1 text-xs text-red-300">이미 사용 중인 닉네임입니다.</div>;
+        if (nickState === "ok") return <div className="mt-1 text-xs text-emerald-300">사용 가능한 닉네임입니다.</div>;
+        return <div className="mt-1 text-xs text-red-300">닉네임 확인 중 오류가 발생했습니다.</div>;
+    };
 
-  return (
-    <AuthCard title="회원가입" sub="이메일/닉네임/비밀번호로 가입합니다.">
-      <form onSubmit={onSubmit} className="space-y-4">
-        {errorMsg && <InlineBanner kind="error" message={errorMsg} />}
-        {successMsg && <InlineBanner kind="success" message={successMsg} />}
+    return (
+        <AuthCard title="회원가입" sub="이메일/닉네임/비밀번호로 가입합니다.">
+            <form onSubmit={onSubmit} className="space-y-4">
+                {errorMsg && <InlineBanner kind="error" message={errorMsg} />}
+                {successMsg && <InlineBanner kind="success" message={successMsg} />}
 
-        <div>
-          <div className="mb-1 text-sm text-text-2">이메일</div>
-          <input className="input" value={email} onChange={(e) => setEmail(e.target.value)} />
-          <EmailHint />
-        </div>
+                <div>
+                    <div className="mb-1 text-sm text-text-2">이메일</div>
+                    <input className="input" value={email} onChange={(e) => setEmail(e.target.value)} />
+                    <EmailHint />
+                </div>
 
-        <div>
-          <div className="mb-1 text-sm text-text-2">닉네임</div>
-          <input className="input" value={nickname} onChange={(e) => setNickname(e.target.value)} />
-          <NickHint />
-        </div>
+                <div>
+                    <div className="mb-1 text-sm text-text-2">닉네임</div>
+                    <input className="input" value={nickname} onChange={(e) => setNickname(e.target.value)} />
+                    <NickHint />
+                </div>
 
-        <div>
-          <div className="mb-1 text-sm text-text-2">비밀번호</div>
-          <input className="input" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
-        </div>
+                <div>
+                    <div className="mb-1 text-sm text-text-2">비밀번호</div>
+                    <input className="input" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+                </div>
 
-        <button className="btn btn-primary w-full" disabled={!canSubmit}>
-          {pending ? "가입 중..." : "회원가입"}
-        </button>
+                <button className="btn btn-primary w-full" disabled={!canSubmit}>
+                    {pending ? "가입 중..." : "회원가입"}
+                </button>
 
-        <button type="button" className="btn btn-ghost w-full" onClick={() => router.push("/auth/login")}>
-          로그인으로 돌아가기
-        </button>
-      </form>
-    </AuthCard>
-  );
+                <button
+                    type="button"
+                    className="btn btn-secondary w-full"
+                    onClick={() => router.push("/auth/login")}
+                >
+                    로그인으로 돌아가기
+                </button>
+            </form>
+        </AuthCard>
+    );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,10 +28,9 @@ export default function RootLayout({
     const isActive = pathname.startsWith(path);
     return `
       group relative px-6 py-3 rounded-2xl font-black text-[16px] uppercase tracking-wider transition-all duration-200 active:scale-90
-      ${
-        isActive
-          ? "text-blue-400 bg-blue-500/15 shadow-inner shadow-blue-500/10"
-          : "text-gray-400 hover:text-white hover:bg-white/10"
+      ${isActive
+        ? "text-blue-400 bg-blue-500/15 shadow-inner shadow-blue-500/10"
+        : "text-gray-400 hover:text-white hover:bg-white/10"
       }
     `;
   };
@@ -76,10 +75,13 @@ export default function RootLayout({
                 <span className="absolute bottom-2 left-1/2 -translate-x-1/2 h-1 w-0 bg-gray-500 rounded-full transition-all duration-300 group-hover:w-4"></span>
               </button>
 
-              <button className="group relative px-6 py-3 rounded-2xl font-black text-[16px] uppercase tracking-wider text-gray-400 hover:text-white hover:bg-white/10 transition-all active:scale-90">
+              <Link
+                href="/me"
+                className="group relative px-6 py-3 rounded-2xl font-black text-[16px] uppercase tracking-wider text-gray-400 hover:text-white hover:bg-white/10 transition-all active:scale-90"
+              >
                 내 페이지
                 <span className="absolute bottom-2 left-1/2 -translate-x-1/2 h-1 w-0 bg-gray-500 rounded-full transition-all duration-300 group-hover:w-4"></span>
-              </button>
+              </Link>
             </nav>
           </div>
 
@@ -95,7 +97,7 @@ export default function RootLayout({
         </header>
 
         {/* 메인 콘텐츠 */}
-        <main className="flex-grow">{children}</main>
+        <main className="flex-grow bg-bg text-text-1">{children}</main>
 
         {/* 푸터 */}
         <footer className="w-full py-14 bg-[#0d0e12] border-t border-white/5 text-gray-600 text-center">

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -29,7 +29,7 @@ export default function MePage() {
       try {
         const rs = await getMe();
         setMe(rs.data);
-      } catch (err) {
+      } catch {
         router.push("/auth/login");
       } finally {
         setLoading(false);
@@ -43,12 +43,12 @@ export default function MePage() {
 
     try {
       const rs = await logout();
-      setSuccessMsg(rs.msg || "로그아웃 되었습니다.");
+      // ✅ 홈으로 메시지를 넘겨서 홈에서 보여주기
+      const msg = encodeURIComponent(rs.msg || "로그아웃 되었습니다.");
+      router.push(`/?success=${msg}`);
+      router.refresh();
     } catch (err: any) {
       setErrorMsg(pickMsg(err, "로그아웃에 실패했습니다."));
-    } finally {
-      router.push("/");
-      router.refresh();
     }
   };
 
@@ -90,19 +90,16 @@ export default function MePage() {
     <div className="min-h-[calc(100vh-180px)] bg-bg text-text-1">
       <div className="mx-auto w-full max-w-4xl px-4 py-10 sm:px-6 lg:px-8 space-y-6">
         <div className="card p-6">
-          {/* 상단 제목 */}
           <div>
             <div className="text-lg font-semibold">마이페이지</div>
             <div className="mt-1 text-sm text-text-3">내 정보 및 보안 설정</div>
           </div>
 
-          {/* 배너 */}
           <div className="mt-4 space-y-3">
             {errorMsg && <InlineBanner kind="error" message={errorMsg} />}
             {successMsg && <InlineBanner kind="success" message={successMsg} />}
           </div>
 
-          {/* 탭 */}
           <div className="mt-6 flex gap-2 border-b border-border pb-3">
             <button
               className={`btn ${tab === "info" ? "btn-primary" : "btn-ghost"}`}
@@ -120,7 +117,6 @@ export default function MePage() {
             </button>
           </div>
 
-          {/* 컨텐츠 */}
           {tab === "info" ? (
             <div className="mt-6 space-y-3">
               <div className="rounded-xl border border-border bg-surface-2 px-4 py-3">
@@ -163,24 +159,23 @@ export default function MePage() {
             </form>
           )}
 
-          {/* ✅ 맨밑 중앙 버튼 */}
           <div className="mt-10 flex justify-center gap-3">
-  <button
-    type="button"
-    onClick={onLogout}
-    className="btn min-w-[140px] bg-red-500/20 text-red-200 border border-red-500/30 hover:bg-red-500/25 active:bg-red-500/35"
-  >
-    로그아웃
-  </button>
+            <button
+              type="button"
+              onClick={onLogout}
+              className="btn min-w-[140px] bg-red-500/20 text-red-200 border border-red-500/30 hover:bg-red-500/25 active:bg-red-500/35"
+            >
+              로그아웃
+            </button>
 
-  <button
-    type="button"
-    className="btn btn-secondary min-w-[140px]"
-    onClick={() => router.push("/")}
-  >
-    홈으로
-  </button>
-</div>
+            <button
+              type="button"
+              className="btn btn-secondary min-w-[140px]"
+              onClick={() => router.push("/")}
+            >
+              홈으로
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import InlineBanner from "@/components/ui/InlineBanner";
+import { getMe, changePassword, type MeResponse } from "@/lib/backend/me";
+import { logout } from "@/lib/backend/authApi";
+import { pickMsg } from "@/lib/backend/types";
+
+type Tab = "info" | "security";
+
+export default function MePage() {
+  const router = useRouter();
+
+  const [tab, setTab] = useState<Tab>("info");
+  const [me, setMe] = useState<MeResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+
+  const [oldPw, setOldPw] = useState("");
+  const [newPw, setNewPw] = useState("");
+  const [pwPending, setPwPending] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      setErrorMsg(null);
+      try {
+        const rs = await getMe();
+        setMe(rs.data);
+      } catch (err) {
+        router.push("/auth/login");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [router]);
+
+  const onLogout = async () => {
+    setErrorMsg(null);
+    setSuccessMsg(null);
+
+    try {
+      const rs = await logout();
+      setSuccessMsg(rs.msg || "로그아웃 되었습니다.");
+    } catch (err: any) {
+      setErrorMsg(pickMsg(err, "로그아웃에 실패했습니다."));
+    } finally {
+      router.push("/");
+      router.refresh();
+    }
+  };
+
+  const onChangePassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErrorMsg(null);
+    setSuccessMsg(null);
+
+    if (!oldPw.trim() || !newPw.trim()) {
+      setErrorMsg("기존 비밀번호와 새 비밀번호를 입력해주세요.");
+      return;
+    }
+
+    setPwPending(true);
+    try {
+      const rs = await changePassword(oldPw, newPw);
+      setSuccessMsg(rs.msg || "비밀번호가 변경되었습니다.");
+      setOldPw("");
+      setNewPw("");
+      setTab("info");
+    } catch (err: any) {
+      setErrorMsg(pickMsg(err, "비밀번호 변경에 실패했습니다."));
+    } finally {
+      setPwPending(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-[calc(100vh-180px)] bg-bg text-text-1 grid place-items-center">
+        <div className="card p-6">로딩 중...</div>
+      </div>
+    );
+  }
+
+  if (!me) return null;
+
+  return (
+    <div className="min-h-[calc(100vh-180px)] bg-bg text-text-1">
+      <div className="mx-auto w-full max-w-4xl px-4 py-10 sm:px-6 lg:px-8 space-y-6">
+        <div className="card p-6">
+          {/* 상단 제목 */}
+          <div>
+            <div className="text-lg font-semibold">마이페이지</div>
+            <div className="mt-1 text-sm text-text-3">내 정보 및 보안 설정</div>
+          </div>
+
+          {/* 배너 */}
+          <div className="mt-4 space-y-3">
+            {errorMsg && <InlineBanner kind="error" message={errorMsg} />}
+            {successMsg && <InlineBanner kind="success" message={successMsg} />}
+          </div>
+
+          {/* 탭 */}
+          <div className="mt-6 flex gap-2 border-b border-border pb-3">
+            <button
+              className={`btn ${tab === "info" ? "btn-primary" : "btn-ghost"}`}
+              onClick={() => setTab("info")}
+              type="button"
+            >
+              정보
+            </button>
+            <button
+              className={`btn ${tab === "security" ? "btn-primary" : "btn-ghost"}`}
+              onClick={() => setTab("security")}
+              type="button"
+            >
+              보안
+            </button>
+          </div>
+
+          {/* 컨텐츠 */}
+          {tab === "info" ? (
+            <div className="mt-6 space-y-3">
+              <div className="rounded-xl border border-border bg-surface-2 px-4 py-3">
+                <div className="text-xs text-text-3">이메일</div>
+                <div className="mt-1 text-sm font-medium text-text-1 break-all">{me.email}</div>
+              </div>
+
+              <div className="rounded-xl border border-border bg-surface-2 px-4 py-3">
+                <div className="text-xs text-text-3">닉네임</div>
+                <div className="mt-1 text-sm font-medium text-text-1">{me.nickname}</div>
+              </div>
+            </div>
+          ) : (
+            <form onSubmit={onChangePassword} className="mt-6 space-y-4">
+              <div>
+                <div className="mb-1 text-sm text-text-2">기존 비밀번호</div>
+                <input
+                  className="input"
+                  type="password"
+                  value={oldPw}
+                  onChange={(e) => setOldPw(e.target.value)}
+                  placeholder="••••"
+                />
+              </div>
+
+              <div>
+                <div className="mb-1 text-sm text-text-2">새 비밀번호</div>
+                <input
+                  className="input"
+                  type="password"
+                  value={newPw}
+                  onChange={(e) => setNewPw(e.target.value)}
+                  placeholder="••••"
+                />
+              </div>
+
+              <button className="btn btn-primary w-full" disabled={pwPending}>
+                {pwPending ? "변경 중..." : "비밀번호 변경"}
+              </button>
+            </form>
+          )}
+
+          {/* ✅ 맨밑 중앙 버튼 */}
+          <div className="mt-10 flex justify-center gap-3">
+  <button
+    type="button"
+    onClick={onLogout}
+    className="btn min-w-[140px] bg-red-500/20 text-red-200 border border-red-500/30 hover:bg-red-500/25 active:bg-red-500/35"
+  >
+    로그아웃
+  </button>
+
+  <button
+    type="button"
+    className="btn btn-secondary min-w-[140px]"
+    onClick={() => router.push("/")}
+  >
+    홈으로
+  </button>
+</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth/AuthCard.tsx
+++ b/src/components/auth/AuthCard.tsx
@@ -9,13 +9,11 @@ export default function AuthCard({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-[calc(100vh-180px)] bg-bg text-text-1">
-      <div className="mx-auto max-w-md px-4 py-10 sm:px-6 lg:px-8">
-        <div className="card p-6 sm:p-8">
-          <div className="text-xl font-semibold">{title}</div>
-          {sub && <div className="mt-1 text-sm text-text-3">{sub}</div>}
-          <div className="mt-6">{children}</div>
-        </div>
+    <div className="bg-bg text-text-1 flex items-center justify-center px-4 py-10 sm:px-6 lg:px-8">
+      <div className="w-full max-w-md card p-6 sm:p-8">
+        <div className="text-xl font-semibold">{title}</div>
+        {sub && <div className="mt-1 text-sm text-text-3">{sub}</div>}
+        <div className="mt-6">{children}</div>
       </div>
     </div>
   );

--- a/src/components/auth/AuthCard.tsx
+++ b/src/components/auth/AuthCard.tsx
@@ -1,0 +1,22 @@
+// src/components/auth/AuthCard.tsx
+export default function AuthCard({
+  title,
+  sub,
+  children,
+}: {
+  title: string;
+  sub?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="min-h-[calc(100vh-180px)] bg-bg text-text-1">
+      <div className="mx-auto max-w-md px-4 py-10 sm:px-6 lg:px-8">
+        <div className="card p-6 sm:p-8">
+          <div className="text-xl font-semibold">{title}</div>
+          {sub && <div className="mt-1 text-sm text-text-3">{sub}</div>}
+          <div className="mt-6">{children}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/InlineBanner.tsx
+++ b/src/components/ui/InlineBanner.tsx
@@ -1,0 +1,20 @@
+export default function InlineBanner({
+  kind,
+  message,
+}: {
+  kind: "error" | "success" | "info";
+  message: string;
+}) {
+  const styles =
+    kind === "error"
+      ? "border-red-500/30 bg-red-500/10 text-red-200"
+      : kind === "success"
+      ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-200"
+      : "border-zinc-700/60 bg-zinc-900/40 text-zinc-200";
+
+  return (
+    <div className={`rounded-xl border p-3 text-sm ${styles}`}>
+      {message}
+    </div>
+  );
+}

--- a/src/lib/backend/authApi.ts
+++ b/src/lib/backend/authApi.ts
@@ -1,0 +1,42 @@
+// src/lib/backend/authApi.ts
+import { apiFetch } from "./client";
+import type { RsData } from "./types";
+
+export type AuthResult = null;
+
+type CheckEmailResponse = { available: boolean };
+type CheckNicknameResponse = { available: boolean };
+
+export function signup(email: string, password: string, nickname: string) {
+  return apiFetch<RsData<AuthResult>>("/api/v1/auth/signup", {
+    method: "POST",
+    body: JSON.stringify({ email, password, nickname }),
+  });
+}
+
+export function login(email: string, password: string) {
+  return apiFetch<RsData<AuthResult>>("/api/v1/auth/login", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+}
+
+export function logout() {
+  return apiFetch<RsData<AuthResult>>("/api/v1/auth/logout", {
+    method: "POST",
+  });
+}
+
+export async function checkEmailAvailable(email: string) {
+  const rs = await apiFetch<RsData<CheckEmailResponse>>(
+    `/api/v1/auth/check-email?email=${encodeURIComponent(email)}`
+  );
+  return rs.data.available; // true면 사용 가능
+}
+
+export async function checkNicknameAvailable(nickname: string) {
+  const rs = await apiFetch<RsData<CheckNicknameResponse>>(
+    `/api/v1/members/check-nickname?nickname=${encodeURIComponent(nickname)}`
+  );
+  return rs.data.available; // true면 사용 가능
+}

--- a/src/lib/backend/client.ts
+++ b/src/lib/backend/client.ts
@@ -1,27 +1,25 @@
 const NEXT_PUBLIC_API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
-export const apiFetch = (url: string, options: RequestInit = {}) => {
-  // options 기본값 설정
-  // ✅ 1. 쿠키를 요청에 포함시키기 위해 필수 옵션 추가
-  options.credentials = "include";
+export const apiFetch = async <T = any>(url: string, options?: RequestInit): Promise<T> => {
+  const nextOptions: RequestInit = { ...(options || {}) };
 
-  if (options.body) {
-    const headers = new Headers(options.headers || {});
-
+  if (nextOptions.body) {
+    const headers = new Headers(nextOptions.headers || {});
     if (!headers.has("Content-Type")) {
       headers.set("Content-Type", "application/json; charset=utf-8");
     }
-
-    options.headers = headers;
+    nextOptions.headers = headers;
   }
 
-  return fetch(`${NEXT_PUBLIC_API_BASE_URL}${url}`, options).then((res) => {
-    if (!res.ok) {
-      return res.json().then((e) => {
-        throw e;
-      });
-    }
+  nextOptions.credentials = "include";
 
-    return res.json();
-  });
+  const res = await fetch(`${NEXT_PUBLIC_API_BASE_URL}${url}`, nextOptions);
+
+  const json = await res.json().catch(() => null);
+
+  if (!res.ok) {
+    throw json ?? { msg: `HTTP ${res.status}` };
+  }
+
+  return json as T;
 };

--- a/src/lib/backend/me.ts
+++ b/src/lib/backend/me.ts
@@ -1,0 +1,19 @@
+import { apiFetch } from "./client";
+import type { RsData } from "./types";
+
+export type MeResponse = {
+  id: number;
+  email: string;
+  nickname: string;
+};
+
+export function getMe() {
+  return apiFetch<RsData<MeResponse>>("/api/v1/members/me");
+}
+
+export function changePassword(oldPassword: string, newPassword: string) {
+  return apiFetch<RsData<null>>("/api/v1/members/me/password", {
+    method: "PUT",
+    body: JSON.stringify({ oldPassword, newPassword }),
+  });
+}

--- a/src/lib/backend/types.ts
+++ b/src/lib/backend/types.ts
@@ -1,0 +1,9 @@
+export type RsData<T> = {
+  resultCode: string;
+  msg: string;
+  data: T;
+};
+
+export function pickMsg(err: any, fallback = "요청 처리 중 오류가 발생했습니다.") {
+  return err?.msg || err?.message || fallback;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,17 +7,21 @@
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,
+
     "module": "esnext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
+
     "incremental": true,
     "plugins": [
       {
         "name": "next"
       }
     ],
+
+    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## 📌 과제 설명
프론트에서 회원가입/로그인/마이페이지 화면을 구현하고, 백엔드 API와 연동하여 인증 플로우를 완성했습니다.  
공통 UI 컴포넌트(AuthCard, InlineBanner)와 공통 fetch 유틸(apiFetch)을 적용해 일관된 UI/에러 처리 방식을 유지했습니다.

---

## 👩‍💻 요구 사항과 구현 내용

- **공통 API 유틸/타입 구성**
  - `apiFetch` 공통 유틸 적용 (`credentials: "include"`로 쿠키 기반 인증 처리)
  - JSON 응답 파싱 및 `res.ok` 기반 에러 처리(throw)로 예외 흐름 통일
  - `RsData<T>` 타입 정의 및 `pickMsg`로 에러 메시지 우선순위 처리(`msg` → `message` → fallback)

- **회원가입 페이지 구현 및 API 연동 (`/auth/signup`)**
  - 이메일/닉네임/비밀번호 입력 UI 구성
  - 회원가입 API 연동: `POST /api/v1/auth/signup`
  - 가입 성공 시 로그인 페이지로 이동
  - 이메일/닉네임 **중복 체크 자동화**
    - 이메일 중복 체크: `GET /api/v1/auth/check-email`
    - 닉네임 중복 체크: `GET /api/v1/members/check-nickname`
    - 디바운스 기반 자동 체크 + 상태 메시지 표시 + 가입 버튼 활성/비활성 처리

- **로그인 페이지 구현 및 API 연동 (`/auth/login`)**
  - 이메일/비밀번호 입력 UI 구성
  - 로그인 API 연동: `POST /api/v1/auth/login` (`credentials include`)
  - 로그인 성공 시 마이페이지(`/me`) 이동 및 `router.refresh()`로 상태 갱신
  - 회원가입 완료 후 로그인 페이지 진입 시 안내 메시지(배너) 노출

- **마이페이지 구현 및 보안 기능 연동 (`/me`)**
  - 내 정보 조회 API 연동: `GET /api/v1/members/me`
  - 미로그인 상태(401 등)일 경우 로그인 페이지로 리다이렉트
  - 탭 UI 구성
    - 정보 탭: 이메일/닉네임 표시
    - 보안 탭: 비밀번호 변경 폼 제공
  - 비밀번호 변경 API 연동: `PUT /api/v1/members/me/password`
  - 로그아웃 API 연동: `POST /api/v1/auth/logout` 후 홈(`/`) 이동 및 `router.refresh()`

---
## 화면 사진
<img width="1897" height="1004" alt="image" src="https://github.com/user-attachments/assets/353e23fe-ae9a-4df3-8ced-3ce8700b88cc" />

<img width="1906" height="974" alt="image" src="https://github.com/user-attachments/assets/d13ddfc1-acd7-4fd4-99de-92d878a9b30a" />

<img width="1905" height="1000" alt="image" src="https://github.com/user-attachments/assets/5dabca12-b947-4e7c-b9b0-2882eef51fbb" />

<img width="1915" height="989" alt="image" src="https://github.com/user-attachments/assets/49576ffe-1d26-46a0-89bc-da75aaf05291" />
