### PR TITLE
[Refactor] 로그인 토큰 만료시 데드 세션 해결

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -57,17 +57,19 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
     try {
       await logout();
+      
+      // ✅ [중요] 로그아웃 시 localStorage에 저장된 apiKey를 반드시 삭제!
+      if (typeof window !== "undefined") {
+        localStorage.removeItem("apiKey");
+      }
+      
     } catch (err: any) {
       console.error(pickMsg(err, "로그아웃 실패"));
     } finally {
-      // UI 먼저 게스트로 돌림
       setAuth({ status: "guest", me: null });
-      // (선택) 일관성 있게 이벤트도 쏴줘도 됨
       window.dispatchEvent(new Event("auth:changed"));
-
       setLogoutPending(false);
       router.push("/");
-      router.refresh(); // 있어도 되고 없어도 됨
     }
   };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,15 +23,15 @@ export default function HomePage() {
   const { search } = useGameSearch();
 
   useEffect(() => {
-    // 1. 게시글 데이터 로드
-    apiFetch("/api/v1/posts?size=6&sort=id,desc").then((res) =>
-      setLatestPosts(res.data.content),
-    );
-    apiFetch("/api/v1/posts?size=6&sort=viewCount,desc").then((res) =>
-      setPopularPosts(res.data.content),
-    );
+    // .catch(() => {})를 추가하여 401 에러가 나도 조용히 넘어가게 합니다.
+    apiFetch("/api/v1/posts?size=6&sort=id,desc")
+      .then((res) => setLatestPosts(res.data.content))
+      .catch(() => console.log("Guest mode: latest posts load skipped"));
 
-    // 2. IGDB 인기 게임 로드
+    apiFetch("/api/v1/posts?size=6&sort=viewCount,desc")
+      .then((res) => setPopularPosts(res.data.content))
+      .catch(() => {});
+
     getIgdbPopularGames(10)
       .then(setIgdbPopularGames)
       .catch(() => {});

--- a/src/lib/backend/authApi.ts
+++ b/src/lib/backend/authApi.ts
@@ -2,27 +2,39 @@
 import { apiFetch } from "./client";
 import type { RsData } from "./types";
 
-export type AuthResult = null;
+export type AuthResult = { memberId: number; apiKey: string };
 
 type CheckEmailResponse = { available: boolean };
 type CheckNicknameResponse = { available: boolean };
 
 export function signup(email: string, password: string, nickname: string) {
-  return apiFetch<RsData<AuthResult>>("/api/v1/auth/signup", {
+  return apiFetch<RsData<null>>("/api/v1/auth/signup", {
     method: "POST",
     body: JSON.stringify({ email, password, nickname }),
   });
 }
 
-export function login(email: string, password: string) {
-  return apiFetch<RsData<AuthResult>>("/api/v1/auth/login", {
+export async function login(email: string, password: string) {
+  const rs = await apiFetch<RsData<AuthResult>>("/api/v1/auth/login", {
     method: "POST",
     body: JSON.stringify({ email, password }),
   });
+
+  // 🔑 서버가 준 apiKey를 localStorage에 저장 (401 복구용 마스터키)
+  if (rs.data?.apiKey) {
+    localStorage.setItem("apiKey", rs.data.apiKey);
+  }
+
+  return rs;
 }
 
-export function logout() {
-  return apiFetch<RsData<AuthResult>>("/api/v1/auth/logout", {
+export async function logout() {
+  // ✅ 로그아웃 시 마스터키도 함께 폐기 (보안상 매우 중요!)
+  if (typeof window !== "undefined") {
+    localStorage.removeItem("apiKey");
+  }
+
+  return apiFetch<RsData<null>>("/api/v1/auth/logout", {
     method: "POST",
   });
 }

--- a/src/lib/backend/client.ts
+++ b/src/lib/backend/client.ts
@@ -1,5 +1,12 @@
 const NEXT_PUBLIC_API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
+// 에러 객체에 상태 코드를 포함시키기 위한 커스텀 인터페이스
+interface ApiError extends Error {
+  status?: number;
+  msg?: string;
+  data?: any;
+}
+
 export const apiFetch = async <T = any>(
   url: string,
   options?: RequestInit
@@ -8,28 +15,47 @@ export const apiFetch = async <T = any>(
     throw new Error("NEXT_PUBLIC_API_BASE_URL is not defined");
   }
 
-  const nextOptions: RequestInit = { ...(options || {}) };
+  const nextOptions: RequestInit = { ...(options || {}), credentials: "include" };
 
-  if (nextOptions.body) {
-    const headers = new Headers(nextOptions.headers || {});
-    if (!headers.has("Content-Type")) {
-      headers.set("Content-Type", "application/json; charset=utf-8");
+  // 1. 기본 헤더 설정
+  const headers = new Headers(nextOptions.headers || {});
+  if (nextOptions.body && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json; charset=utf-8");
+  }
+  nextOptions.headers = headers;
+
+  // 2. 1차 요청 시도
+  let res = await fetch(`${NEXT_PUBLIC_API_BASE_URL}${url}`, nextOptions);
+
+  // 🚨 [핵심] 401 Unauthorized (5분 만료) 발생 시 처리
+  if (res.status === 401) {
+    const savedApiKey = typeof window !== "undefined" ? localStorage.getItem("apiKey") : null;
+
+    if (savedApiKey) {
+      // 백엔드 필터는 "Bearer [ApiKey] [AccessToken]" 형식을 인식합니다.
+      // 여기서는 토큰이 만료되었으므로 AccessToken 자리에 임시 값을 넣거나 비워둡니다.
+      const retryHeaders = new Headers(nextOptions.headers);
+      retryHeaders.set("Authorization", `Bearer ${savedApiKey} expired_token`);
+
+      const retryRes = await fetch(`${NEXT_PUBLIC_API_BASE_URL}${url}`, {
+        ...nextOptions,
+        headers: retryHeaders,
+      });
+
+      if (retryRes.ok) res = retryRes;
     }
-    nextOptions.headers = headers;
   }
 
-  nextOptions.credentials = "include";
-
-  const res = await fetch(`${NEXT_PUBLIC_API_BASE_URL}${url}`, nextOptions);
-
+  // 3. 응답 파싱
   const json = await res.json().catch(() => null);
 
+  // 4. [수정] 객체가 아닌 Error 객체를 던져서 [object Object] 방지
   if (!res.ok) {
-    throw {
-      status: res.status,
-      ...(json ?? {}),
-      msg: json?.msg ?? `HTTP ${res.status}`,
-    };
+    const error: ApiError = new Error(json?.msg || `HTTP Error ${res.status}`);
+    error.status = res.status;
+    error.msg = json?.msg;
+    error.data = json?.data;
+    throw error;
   }
 
   return json as T;


### PR DESCRIPTION
## 📌 과제 설명
- **배경**: 보안 강화를 위해 설정된 짧은 토큰 만료 시간(5분)으로 인해, 유저가 활동 중 예고 없이 로그아웃되는 '데드 세션(Dead Session)' 현상이 발생했습니다.
- **목표**: 보안성은 유지하되(토큰 수명 5분 유지), 토큰 만료 시 별도의 로그인 없이 **ApiKey를 활용해 세션을 자동으로 연장**하는 무중단 인증 시스템을 구축합니다.

## 👩‍💻 요구 사항과 구현 내용
### 1. ApiKey 생명주기 관리 (`authApi.ts`)
- **구현**: 로그인 성공 시 서버가 발급한 `apiKey`를 브라우저의 **LocalStorage**에 안전하게 보관하도록 수정했습니다.
- **보안**: 로그아웃 시 토큰 폐기와 동시에 LocalStorage의 `apiKey`도 즉시 삭제하여 공용 PC 등에서의 보안 사고를 방지했습니다.

### 2. 401 에러 감지 및 자동 재인증 로직 (`client.ts`)
- **구현**: 공통 fetch 모듈인 `apiFetch`에 **인터셉터(Interceptor)** 로직을 추가했습니다.
- **동작**: 토큰 만료(`401 Unauthorized`) 발생 시, 저장된 `apiKey`를 백엔드 필터 규격(`Bearer [ApiKey] [ExpiredToken]`)에 맞춰 헤더에 실어 **자동으로 재요청**을 보냅니다.
- **결과**: 사용자는 토큰 만료를 인지하지 못한 채 끊김 없이 서비스를 이용할 수 있습니다.

### 3. 에러 핸들링 고도화
- **수정**: 일반 객체 형태의 예외 처리를 **표준 `Error` 객체** 기반으로 교체했습니다.
- **효과**: 개발 환경에서 발생하던 `[object Object]` 에러 창 문제를 해결하고, 실제 백엔드에서 전달하는 명확한 텍스트 메시지를 노출합니다.